### PR TITLE
Invoke-PowerShell: fix quoting issue

### DIFF
--- a/Invoke-PowerShell.ps1
+++ b/Invoke-PowerShell.ps1
@@ -1,5 +1,5 @@
 <#PSScriptInfo
-.VERSION 1.0.3
+.VERSION 1.0.4
 .AUTHOR Roman Kuzmin
 .COPYRIGHT (c) Roman Kuzmin
 .TAGS Test
@@ -27,11 +27,11 @@
 trap {Write-Error -ErrorRecord $_}
 
 if ($PSVersionTable.PSVersion.Major -eq 2) {
-	powershell.exe -Version 2 @args
+	powershell.exe -Version 2 @($args.Replace('"','"""'))
 }
 elseif ($PSVersionTable.PSVersion.Major -le 5) {
-	powershell.exe @args
+	powershell.exe @($args.Replace('"','"""'))
 }
 else {
-	& ([System.Diagnostics.Process]::GetCurrentProcess().Path) @args
+	& ([System.Diagnostics.Process]::GetCurrentProcess().Path) @($args.Replace('"','"""'))
 }


### PR DESCRIPTION
Even on Linux, quotation marks get swallowed up unless you escape them in some manner. This seemed to be the simplest approach, so I went with it. I admittedly didn't test it on PowerShell 2.0, but I have to assume it's the same story there.